### PR TITLE
Do not fail if opencast is from e.g. LDAP

### DIFF
--- a/opencast/debian/opencast-7-common.postrm
+++ b/opencast/debian/opencast-7-common.postrm
@@ -44,7 +44,7 @@ del_group() {
 del_user() {
     if getent passwd $OC_USER > /dev/null 2>&1; then
         if [ -x "`which deluser 2>/dev/null`" ]; then
-            deluser $OC_USER
+            deluser $OC_USER || true
         else
             echo >&2 "Not removing \`$OC_USER' system account" \
               "because deluser command was not found."


### PR DESCRIPTION
Hi,

our opencast server uses a LDAP-provided opencast user. Of course this user cannot be deleted by the postrm script. The easiest solution is not to let the postrm script fail if the user deletion fails. I would love to see this minor change also in the other branches. If you need PRs for them as well, please tell me.

Thanks,

Christopher